### PR TITLE
Try remove unsupported text in font.

### DIFF
--- a/Hathor_OLP/variables.xml
+++ b/Hathor_OLP/variables.xml
@@ -557,7 +557,7 @@
 					<p>牵引 GP-XP Large Industrial Battery 到轨道激光平台（在 1G 重力环境中需要大牵引枪）</p>
 				</STAGE_1_7>
 				<STAGE_1_PARKOUR_NOTE>
-					<p>某些房间可以直接跑酷进入，不必浪费钥匙！</p>
+					<p>可以跑酷就不必消耗密匙！</p>
 				</STAGE_1_PARKOUR_NOTE>
 				<ITEM_PAF_KEYS>
 					<p>PAF 钥匙</p>


### PR DESCRIPTION
Try remove unsupported text due font issue.

I noticed that some Chinese characters are not supported in special fonts, so I replaced them with simple text that may be supported. But because I don't know the name of the font used there and I haven't tested it in practice, the replaced text may still have display problems.

##### Old
```
某些房间可以直接跑酷进入，不必浪费钥匙！
```
##### New
```
可以跑酷就不必消耗密匙！
```
The character "钥匙" cannot be fully displayed. Its synonym "密匙" can be used in informal documents.
The characters "间", "进" and "费" cannot be displayed and are removed directly.
The newly added word "就" and "消耗" may still have the problem of not being displayed.

![image](https://github.com/user-attachments/assets/6bb9244f-91fa-47fc-b860-d6ed33a5f385)

For the root cause, I suggest changing the font to `Noto Sans CJK SC` (But some of the stylization may be lost.)
